### PR TITLE
slicer 0.0.8 rebuild py3.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
     #   https://github.com/interpretml/slicer/blob/v0.0.8/slicer/test_slicer.py#L13-L19
     # and
     #   https://github.com/interpretml/slicer/blob/v0.0.8/.github/workflows/run_tests.yml#L27C23-L27C54
-    - pandas
+    - pandas <3
     - scipy
     - numpy
     # pytorch is not available for PY3.14

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,11 @@ source:
     - patches/0001-fix-tests-relative-imports.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
-  build:
-    - patch     # [not win]
-    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -41,12 +38,14 @@ test:
     - pandas
     - scipy
     - numpy
-    - pytorch
+    # pytorch is not available for PY3.14
+    - pytorch  # [py<314]
   source_files:
     - slicer/test_slicer.py
   commands:
     - pip check
-    - pytest -vv slicer/test_slicer.py
+    # Skip 3.14 -> E ModuleNotFoundError: No module named 'torch'
+    - pytest -vv slicer/test_slicer.py  # [py<314]
 
 about:
   home: https://github.com/interpretml/slicer


### PR DESCRIPTION
slicer 0.0.8 

**Destination channel:** Defaults

### Links

- [PKG-13092]
- dev_url:        https://github.com/interpretml/slicer/tree/v0.0.8
- conda_forge:    https://github.com/conda-forge/slicer-feedstock
- pypi:           https://pypi.org/project/slicer/0.0.8
- pypi inspector: https://inspector.pypi.io/project/slicer/0.0.8

### Explanation of changes:

- rebuild to release py3.14


[PKG-13092]: https://anaconda.atlassian.net/browse/PKG-13092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ